### PR TITLE
Add custom validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   configs: {
     all: {
       rules: {
+        'spark/custom-validation': 'error',
         'spark/gateway-direction': 'error',
       },
     },

--- a/rules/custom-validation.js
+++ b/rules/custom-validation.js
@@ -1,0 +1,10 @@
+/**
+ * Rule that delegates to custom validation functions registered during runtime
+ */
+module.exports = function() {
+  function check(node, reporter) {
+    window.ProcessMaker.EventBus.$emit('modeler-validate', node, reporter);
+  }
+
+  return { check };
+};


### PR DESCRIPTION
This PR allows users to add custom validation to the modeler during runtime, as described in the modeler docs at https://github.com/ProcessMaker/modeler#adding-validation-rules-during-runtime.