### PR TITLE
Remove all spark references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# modeler-plugin-spark
+# modeler-plugin-processmaker

--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@ module.exports = {
   configs: {
     all: {
       rules: {
-        'spark/custom-validation': 'error',
-        'spark/gateway-direction': 'error',
-        'spark/call-activity-child-process': 'error',
-        'spark/call-activity-sequence-flow': 'error',
+        'processmaker/custom-validation': 'error',
+        'processmaker/gateway-direction': 'error',
+        'processmaker/call-activity-child-process': 'error',
+        'processmaker/call-activity-sequence-flow': 'error',
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bpmnlint-plugin-spark",
+  "name": "bpmnlint-plugin-processmaker",
   "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "bpmnlint-plugin-spark",
+  "name": "bpmnlint-plugin-processmaker",
   "version": "1.0.1",
-  "description": "BPMNLint plugin for BPM Spark",
+  "description": "BPMNLint plugin for BPM ProcessMaker",
   "main": "index.js",
   "scripts": {
     "test": "mocha test.js"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ProcessMaker/bpmnlint-plugin-spark.git"
+    "url": "git+https://github.com/ProcessMaker/bpmnlint-plugin.git"
   },
   "keywords": [
     "bpmnlint",
     "plugin"
   ],
   "bugs": {
-    "url": "https://github.com/ProcessMaker/bpmnlint-plugin-spark/issues"
+    "url": "https://github.com/ProcessMaker/bpmnlint-plugin/issues"
   },
-  "homepage": "https://github.com/ProcessMaker/bpmnlint-plugin-spark#readme",
+  "homepage": "https://github.com/ProcessMaker/bpmnlint-plugin#readme",
   "dependencies": {
     "bpmnlint": "^5.0.0",
     "bpmnlint-utils": "^1.0.1",


### PR DESCRIPTION
This package is still referencing the name 'spark'. All references have been removed and updated to 'processmaker'.

**IMPORTANT NOTE:**
**BEFORE** this branch can be merged, the package **[bpmnlint-plugin-spark](https://www.npmjs.com/package/bpmnlint-plugin-spark/v/1.0.0)** in the NPM Registry needs to be deprecated and a new package named **bpmnlint-plugin-processmaker** needs to be published.

Dependency Branch: [Modeler bug/491](https://github.com/ProcessMaker/modeler/pull/522)

closes [#491](https://github.com/ProcessMaker/modeler/issues/491)