### PR TITLE
Remove `ID required` for documentation and loops

### DIFF
--- a/rules/id-required.js
+++ b/rules/id-required.js
@@ -26,8 +26,15 @@ module.exports = function() {
     ]);
   }
 
+  function isLoopCharacteristic(node) {
+    return isAny(node, [
+        'bpmn:MultiInstanceLoopCharacteristics',
+        'bpmn:StandardLoopCharacteristics',
+    ]);
+  }
+
   function check(node, reporter) {
-    if (is(node, 'bpmn:Definitions') || isNonBpmnType(node) || isEventDefinition(node)) {
+    if (is(node, 'bpmn:Definitions') || isNonBpmnType(node) || isEventDefinition(node) || isLoopCharacteristic(node)) {
       return;
     }
 

--- a/rules/id-required.js
+++ b/rules/id-required.js
@@ -33,8 +33,18 @@ module.exports = function() {
     ]);
   }
 
+  function isDocumentation(node) {
+    return isAny(node, [
+      'bpmn:Documentation',
+    ]);
+  }
+
   function check(node, reporter) {
-    if (is(node, 'bpmn:Definitions') || isNonBpmnType(node) || isEventDefinition(node) || isLoopCharacteristic(node)) {
+    if (is(node, 'bpmn:Definitions')
+        || isDocumentation(node)
+        || isEventDefinition(node)
+        || isLoopCharacteristic(node)
+        || isNonBpmnType(node)) {
       return;
     }
 

--- a/test-diagrams/documentation.valid.bpmn
+++ b/test-diagrams/documentation.valid.bpmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event">
+      <bpmn:outgoing>node_4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_2" name="Form Task" pm:assignment="requester">
+      <bpmn:documentation>&lt;p&gt;Test documentation&lt;/p&gt;</bpmn:documentation>
+      <bpmn:incoming>node_4</bpmn:incoming>
+      <bpmn:outgoing>node_5</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="node_3" name="End Event">
+      <bpmn:incoming>node_5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_4" sourceRef="node_1" targetRef="node_2" />
+    <bpmn:sequenceFlow id="node_5" sourceRef="node_2" targetRef="node_3" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="120" y="325" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="255" y="305" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="470" y="325" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_4_di" bpmnElement="node_4">
+        <di:waypoint x="138" y="343" />
+        <di:waypoint x="313" y="343" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_5_di" bpmnElement="node_5">
+        <di:waypoint x="313" y="343" />
+        <di:waypoint x="488" y="343" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test-diagrams/loop-characteristics.valid.bpmn
+++ b/test-diagrams/loop-characteristics.valid.bpmn
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="Start Event">
+      <bpmn:outgoing>node_4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_2" name="Form Task" isForCompensation="true" pm:assignment="requester">
+      <bpmn:incoming>node_4</bpmn:incoming>
+      <bpmn:outgoing>node_5</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true" />
+    </bpmn:task>
+    <bpmn:endEvent id="node_3" name="End Event">
+      <bpmn:incoming>node_5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_4" sourceRef="node_1" targetRef="node_2" />
+    <bpmn:sequenceFlow id="node_5" sourceRef="node_2" targetRef="node_3" />
+    <bpmn:task id="node_7" name="Form Task" pm:assignment="requester">
+      <bpmn:incoming>node_9</bpmn:incoming>
+      <bpmn:outgoing>node_12</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics />
+    </bpmn:task>
+    <bpmn:startEvent id="node_8" name="Start Event">
+      <bpmn:outgoing>node_9</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="node_9" sourceRef="node_8" targetRef="node_7" />
+    <bpmn:endEvent id="node_11" name="End Event">
+      <bpmn:incoming>node_12</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_12" sourceRef="node_7" targetRef="node_11" />
+    <bpmn:startEvent id="node_13" name="Start Event">
+      <bpmn:outgoing>node_15</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_14" name="Form Task" pm:assignment="requester">
+      <bpmn:incoming>node_15</bpmn:incoming>
+      <bpmn:outgoing>node_17</bpmn:outgoing>
+      <bpmn:standardLoopCharacteristics />
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_15" sourceRef="node_13" targetRef="node_14" />
+    <bpmn:endEvent id="node_16" name="End Event">
+      <bpmn:incoming>node_17</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_17" sourceRef="node_14" targetRef="node_16" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="160" y="210" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="330" y="190" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="570" y="210" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_4_di" bpmnElement="node_4">
+        <di:waypoint x="178" y="228" />
+        <di:waypoint x="388" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_5_di" bpmnElement="node_5">
+        <di:waypoint x="388" y="228" />
+        <di:waypoint x="588" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_7_di" bpmnElement="node_7">
+        <dc:Bounds x="330" y="330" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_8_di" bpmnElement="node_8">
+        <dc:Bounds x="160" y="350" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_9_di" bpmnElement="node_9">
+        <di:waypoint x="178" y="368" />
+        <di:waypoint x="388" y="368" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_11_di" bpmnElement="node_11">
+        <dc:Bounds x="570" y="350" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_12_di" bpmnElement="node_12">
+        <di:waypoint x="388" y="368" />
+        <di:waypoint x="588" y="368" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_13_di" bpmnElement="node_13">
+        <dc:Bounds x="160" y="490" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_14_di" bpmnElement="node_14">
+        <dc:Bounds x="330" y="470" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_15_di" bpmnElement="node_15">
+        <di:waypoint x="178" y="508" />
+        <di:waypoint x="388" y="508" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_16_di" bpmnElement="node_16">
+        <dc:Bounds x="570" y="490" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_17_di" bpmnElement="node_17">
+        <di:waypoint x="388" y="508" />
+        <di:waypoint x="588" y="508" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test.js
+++ b/test.js
@@ -92,6 +92,9 @@ RuleTester.verify('id-required', idRequiredRule, {
     },
     {
       moddleElement: readModdle('./test-diagrams/loop-characteristics.valid.bpmn')
+    },
+    {
+      moddleElement: readModdle('./test-diagrams/documentation.valid.bpmn')
     }
   ],
   invalid: [

--- a/test.js
+++ b/test.js
@@ -89,6 +89,9 @@ RuleTester.verify('id-required', idRequiredRule, {
     },
     {
       moddleElement: readModdle('./test-diagrams/event-definitions.valid.bpmn')
+    },
+    {
+      moddleElement: readModdle('./test-diagrams/loop-characteristics.valid.bpmn')
     }
   ],
   invalid: [


### PR DESCRIPTION
Fixes [Modeler 1255](https://github.com/ProcessMaker/modeler/issues/1255).

This adds two conditions for early return to the ID required validation:
 - if the node is a documentation node
 - if the node is a loop characteristic node.

Two test fixtures have been added and the test suite updated.