### PR TITLE
FOUR-4331: Error in auto-validate with Data connector

### DIFF
--- a/rules/call-activity-child-process.js
+++ b/rules/call-activity-child-process.js
@@ -43,7 +43,13 @@ module.exports = function() {
 function checkValidProcesses(processes, calledElement, startEvent) {
   const [bpmnId, processId] = calledElement.split('-');
   return processes.find(process => {
-    if (process.id == processId) {
+    if (process.id == processId || process.package_key == processId) {
+      // System processes don't have a start event configured in the callActivity
+      // so we won't verify it
+      if(process.category && process.category.is_system) {
+        return true;
+      }
+
       return filterValidStartEvents(process.events).find(event => event.id == startEvent) != undefined;
     }
     return false;


### PR DESCRIPTION
As part of fixes for [https://processmaker.atlassian.net/browse/FOUR-4331](https://processmaker.atlassian.net/browse/FOUR-4331)

Modeler now will get the list of all processes (including is_system = 1 ones). System processes are used by packages used by processes and will be ignored in the validation.