### PR TITLE
 Bugfix FOUR 4924 Auto validate BPMN issue when task have any content in documentation

### DIFF
--- a/rules/id-required.js
+++ b/rules/id-required.js
@@ -23,6 +23,7 @@ module.exports = function() {
       'bpmn:TimeDate',
       'bpmn:TimeDuration',
       'bpmn:TimerEventDefinition',
+      'bpmn:Documentation',
     ]);
   }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Have a process with form tasks
2. pick any task and add any content to the Documentation -> Description property
3. Enable "Auto validate" and see the error: Processmaker/Id-Required Element is missing ID

## Solution
- Added "Documentation" to the array of definitions that do not require the "required id" rule check.

## How to Test
Please follow the "Reproduction Steps" of above in order to test the solution.

## Related Tickets & Packages
- [FOUR-4924](https://processmaker.atlassian.net/browse/FOUR-4924)