### PR TITLE
Tags that does not require ID v4.2

### DIFF
--- a/rules/id-required.js
+++ b/rules/id-required.js
@@ -24,6 +24,9 @@ module.exports = function() {
       'bpmn:TimeDuration',
       'bpmn:TimerEventDefinition',
       'bpmn:Documentation',
+      'bpmn:InputOutputSpecification',
+      'bpmn:InputSet',
+      'bpmn:OutputSet',
     ]);
   }
 
@@ -35,7 +38,7 @@ module.exports = function() {
     const nodeId = (node.id || '').trim();
 
     if (nodeId.length === 0) {
-      reporter.report(null, 'Element is missing ID');
+      reporter.report(null, 'Element is missing ID ' + node.$type);
       return;
     }
   }


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-5102 observation (ID validation messages)

When a DataObject or DataStore is connected to a Task.

![image](https://user-images.githubusercontent.com/8028650/151839853-f768a78b-0562-4ac4-afa9-e39d6cc946c0.png)

**Fix:**
- ID is not required for the input output elements.

**How to test**
Create a process like this:
![image](https://user-images.githubusercontent.com/8028650/151840359-324de944-3bca-42c5-95d4-f9915a913f93.png)
