### PR TITLE
Bugfix FOUR-6033 - Auto validate is not working with the docusing task and Actions By Email task

### DIFF
--- a/rules/call-activity-child-process.js
+++ b/rules/call-activity-child-process.js
@@ -45,8 +45,8 @@ function checkValidProcesses(processes, calledElement, startEvent) {
   return processes.find(process => {
     if (process.id == processId || process.package_key == processId) {
       // System processes don't have a start event configured in the callActivity
-      // so we won't verify it
-      if(process.category && process.category.is_system) {
+      // so we won't verify it.
+      if (!isAllowedProcess(process.package_key) && process.category && process.category.is_system) {
         return true;
       }
 
@@ -54,6 +54,12 @@ function checkValidProcesses(processes, calledElement, startEvent) {
     }
     return false;
   }) !== undefined;
+}
+
+function isAllowedProcess(packageKey) {
+  return [
+    'package-actions-by-email/sub-process',
+  ].includes(packageKey);
 }
 
 function filterValidStartEvents(events) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Auto Validate does not show any errors for Docusign and Actions by Email tasks in modeler.

1. Create a Process
2. Add a Start event-form task-end event
3. Add a Docusing Task and Actions By Email task
4. Click on Auto Validate.

## Solution
- Due to  "Actions By Email Process" changed from being a non system process to a **system process**, the linter bypassed the process validation.
- The proposed solution is that some processes such as "Actions by email" can be validated again.

## How to Test
- To test you will need to `npm link` in BPMN Plugin folder and `npm link bpmnlint-plugin-processmaker` in Modeler, then compile modeler running `npm run build-bundle` and copy/paste the content in ProcessMaker Core and recompile core.
- You can also run `npm run tests` in bpmnlint-plugin-processmaker project.

Working Video:

https://user-images.githubusercontent.com/90741874/169122789-34981eb5-58f9-40a9-8061-8a2cab5c4dfb.mov

## Related Tickets & Packages
- [FOUR-6033](https://processmaker.atlassian.net/browse/FOUR-6033)