### PR TITLE
Bugfix FOUR-6033-a - Auto validate is not working with the docusing task

### DIFF
--- a/rules/call-activity-child-process.js
+++ b/rules/call-activity-child-process.js
@@ -59,6 +59,7 @@ function checkValidProcesses(processes, calledElement, startEvent) {
 function isAllowedProcess(packageKey) {
   return [
     'package-actions-by-email/sub-process',
+    'DocuSignSendEnvelope',
   ].includes(packageKey);
 }
 


### PR DESCRIPTION
## Issue & Reproduction Steps

Auto Validate does not show any errors for Docusign tasks in modeler.

1. Create a Process.
2. Add a Start event-form task-end event.
3. Add a Docusing Task.
4. Click on Auto Validate.

## Solution

- In my previous tests the calledElement of the Docusign task had a Process Id assigned, now it is set as: `ProcessId-DocuSignSendEnvelope`. 
- The proposed solution is to add `DocuSignSendEnvelope` to the list of process to be validated.

## How to Test

- To test you will need to `npm link` in BPMN Plugin folder and `npm link bpmnlint-plugin-processmaker` in Modeler, then compile modeler running `npm run build-bundle` and copy/paste the content in ProcessMaker Core and recompile core.
- You can also run `npm run tests` in bpmnlint-plugin-processmaker project.

Working Video:

https://user-images.githubusercontent.com/90741874/169902760-fbffa90b-ac6f-41dd-af10-430bbfd6b2f4.mov

## Related Tickets & Packages
- [FOUR-6033](https://processmaker.atlassian.net/browse/FOUR-6033)

[FOUR-6033]: https://processmaker.atlassian.net/browse/FOUR-6033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-6033]: https://processmaker.atlassian.net/browse/FOUR-6033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ