### PR TITLE
Revert CallActivityChildProcess validation on ABE and Docusign elements

### DIFF
--- a/rules/call-activity-child-process.js
+++ b/rules/call-activity-child-process.js
@@ -46,7 +46,7 @@ function checkValidProcesses(processes, calledElement, startEvent) {
     if (process.id == processId || process.package_key == processId) {
       // System processes don't have a start event configured in the callActivity
       // so we won't verify it.
-      if (!isAllowedProcess(process.package_key) && process.category && process.category.is_system) {
+      if (process.category && process.category.is_system) {
         return true;
       }
 
@@ -54,12 +54,6 @@ function checkValidProcesses(processes, calledElement, startEvent) {
     }
     return false;
   }) !== undefined;
-}
-
-function isAllowedProcess(packageKey) {
-  return [
-    'package-actions-by-email/sub-process',
-  ].includes(packageKey);
 }
 
 function filterValidStartEvents(events) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Call Activity Error is shown.

1. Create a Process
2. Add a Start event-form task-end event
3. Add a Docusing Task and Actions By Email task
4. Click on Auto Validate.

## Solution
- Revert CallActivityChildProcess validation on Actions by Email and Docusign elements.

## Related Tickets & Packages
- [FOUR-6033](https://processmaker.atlassian.net/browse/FOUR-6033)
- [FOUR-5307](https://processmaker.atlassian.net/browse/FOUR-5307)

[FOUR-6033]: https://processmaker.atlassian.net/browse/FOUR-6033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-5307]: https://processmaker.atlassian.net/browse/FOUR-5307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ